### PR TITLE
output: Add fast shutdown, max session duration. Rename metric labels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.test
 /BUILD/*
 /testdata/production
+config.yml

--- a/base/bsupport/pipelineworkerbase_test.go
+++ b/base/bsupport/pipelineworkerbase_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/relex/gotils/logger"
 	"github.com/relex/slog-agent/base"
 	"github.com/relex/slog-agent/defs"
+	"github.com/relex/slog-agent/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +47,7 @@ func (worker *testPipelineWorker) onInput(inBuffer []*base.LogRecord, timeout <-
 	case worker.outputChannel <- outBuffer:
 		break
 	case <-timeout:
-		worker.Logger().Errorf("BUG: timeout sending to channel: %d records", len(outBuffer))
+		worker.Logger().Errorf("BUG: timeout sending to channel: %d records. stack=%s", len(outBuffer), util.Stack())
 		break
 	}
 }

--- a/buffer/hybridbuffer/bufferer.go
+++ b/buffer/hybridbuffer/bufferer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/relex/gotils/promexporter"
 	"github.com/relex/slog-agent/base"
 	"github.com/relex/slog-agent/defs"
+	"github.com/relex/slog-agent/util"
 )
 
 // bufferer is an intermediate buffer buf which saves log chunks to disk temporarily if needed
@@ -135,7 +136,7 @@ func (buf *bufferer) Destroy() {
 
 	buf.logger.Infof("waiting for feeder: in=%d out=%d", len(buf.inputChannel), buf.feeder.NumOutput())
 	if !buf.feeder.Stopped().Wait(runTimeout) {
-		buf.logger.Errorf("BUG: couldn't stop feeder in time")
+		buf.logger.Errorf("BUG: couldn't stop feeder in time. stack=%s", util.Stack())
 	}
 }
 

--- a/buffer/hybridbuffer/chunkoperator.go
+++ b/buffer/hybridbuffer/chunkoperator.go
@@ -119,11 +119,11 @@ func (op *chunkOperator) LoadChunk(chunkRef *base.LogChunk) bool {
 		return true
 	}
 	if !chunkRef.Saved {
-		op.logger.Errorf("BUG: cannot load unsaved chunk id=%s: %s", chunkRef.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot load unsaved chunk id=%s. stack=%s", chunkRef.ID, util.Stack())
 		return false
 	}
 	if op.maybeDir == nil {
-		op.logger.Errorf("BUG: cannot load chunk id=%s with nil dir: %s", chunkRef.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot load chunk id=%s with nil dir. stack=%s", chunkRef.ID, util.Stack())
 		return false
 	}
 
@@ -143,7 +143,7 @@ func (op *chunkOperator) UnloadChunk(chunkRef *base.LogChunk) bool {
 		return true
 	}
 	if chunkRef.Data == nil {
-		op.logger.Errorf("BUG: cannot unload nil chunk id=%s: %s", chunkRef.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot unload nil chunk id=%s. stack=%s", chunkRef.ID, util.Stack())
 		return false
 	}
 	if op.maybeDir == nil {
@@ -174,11 +174,11 @@ func (op *chunkOperator) RemoveChunk(chunk base.LogChunk) {
 		return
 	}
 	if chunk.Data == nil {
-		op.logger.Errorf("BUG: cannot remove nil chunk id=%s: %s", chunk.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot remove nil chunk id=%s. stack=%s", chunk.ID, util.Stack())
 		return
 	}
 	if op.maybeDir == nil {
-		op.logger.Errorf("BUG: cannot remove chunk id=%s with nil dir: %s", chunk.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot remove chunk id=%s with nil dir. stack=%s", chunk.ID, util.Stack())
 		return
 	}
 
@@ -205,7 +205,7 @@ func (op *chunkOperator) OnChunkRecovered(chunk base.LogChunk) {
 	op.metrics.persistentChunks.Inc() // update before condition check
 
 	if op.maybeDir == nil {
-		op.logger.Errorf("BUG: cannot check size of recovered chunk id=%s with nil dir: %s", chunk.ID, util.Stack())
+		op.logger.Errorf("BUG: cannot check size of recovered chunk id=%s with nil dir. stack=%s", chunk.ID, util.Stack())
 		return
 	}
 

--- a/defs/params.go
+++ b/defs/params.go
@@ -46,7 +46,7 @@ var (
 	IntermediateFlushInterval = 1 * time.Second
 
 	// ParallelizationBufferMaxNumLogs defines the numbers of logs to process before switching to next parallel worker
-	// Lower value improves parallelization but reduces the size of output chunk files
+	// Lower value improves parallelization but reduces the size of output chunks
 	// e.g. 25000 logs * 250 bytes avg / 20 compression ratio ~= 200-300KB chunk(s)
 	ParallelizationBufferMaxNumLogs = 25000
 
@@ -73,8 +73,8 @@ var (
 )
 
 var (
-	// ForwarderMaxBuffersForAck is the max number of chunk files waiting in cleanup stage before ACK
-	ForwarderMaxBuffersForAck = 10
+	// ForwarderMaxPendingChunksForAck is the max number of chunks waiting in cleanup stage before ACK
+	ForwarderMaxPendingChunksForAck = 10
 
 	// ForwarderConnectionTimeout is for establishing a TCP connection to upstream
 	ForwarderConnectionTimeout = 60 * time.Second

--- a/input/baseinput/logbufferaggregator.go
+++ b/input/baseinput/logbufferaggregator.go
@@ -53,7 +53,7 @@ func (sess *logBufferAggregatorSink) Accept(buffer []*base.LogRecord) {
 	case sess.outputChannel <- reusableBuffer:
 		break
 	case <-sess.sendTimeout.C:
-		sess.logger.Errorf("BUG: timeout flushing: %d records", len(reusableBuffer))
+		sess.logger.Errorf("BUG: timeout flushing: %d records. stack=%s", len(reusableBuffer), util.Stack())
 		break
 	}
 }

--- a/input/baseinput/logmessageaggregator.go
+++ b/input/baseinput/logmessageaggregator.go
@@ -48,7 +48,7 @@ func (sess *logMessageAggregatorSink) Accept(value []byte) {
 	case sess.outputChannel <- scopy:
 		return
 	case <-sess.sendTimeout.C:
-		sess.logger.Error("BUG: timeout sending to channel: ", scopy)
+		sess.logger.Errorf("BUG: timeout sending to channel: \"%s\". stack=%s", scopy, util.Stack())
 		break
 	}
 }

--- a/orchestrate/obase/pipelinechannel.go
+++ b/orchestrate/obase/pipelinechannel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/relex/slog-agent/base"
 	"github.com/relex/slog-agent/base/bsupport"
 	"github.com/relex/slog-agent/defs"
+	"github.com/relex/slog-agent/util"
 )
 
 // PipelineChannel is an alias to write-only channel of log records
@@ -54,7 +55,7 @@ func (cache *PipelineChannelLocalBuffer) Flush(now time.Time, sendTimeout *time.
 		// TODO: update metrics
 		break
 	case <-sendTimeout.C:
-		logger.Errorf("BUG: timeout flushing: %d records for %s", len(reusableLogBuffer), loggingKey)
+		logger.Errorf("BUG: timeout flushing: %d records for %s. stack=%s", len(reusableLogBuffer), loggingKey, util.Stack())
 		break
 	}
 }

--- a/orchestrate/osingleton/orchestrator.go
+++ b/orchestrate/osingleton/orchestrator.go
@@ -55,7 +55,7 @@ func (oc *singletonOrchestratorChild) Accept(buffer []*base.LogRecord) {
 		// TODO: update metrics
 		break
 	case <-oc.sendTimeout.C:
-		oc.logger.Errorf("BUG: timeout flushing: %d records", len(reusableBuffer))
+		oc.logger.Errorf("BUG: timeout flushing: %d records. stack=%s", len(reusableBuffer), util.Stack())
 		break
 	}
 }

--- a/output/baseoutput/clientmetrics.go
+++ b/output/baseoutput/clientmetrics.go
@@ -12,6 +12,7 @@ type clientMetrics struct {
 	queuedChunksPendingAck  promexporter.RWGauge // Current numbers of chunks waiting for ACK, including read and unread chunks by acknowledger
 	networkErrorsTotal      promexporter.RWCounter
 	nonNetworkErrorsTotal   promexporter.RWCounter
+	openedSessionsTotal     promexporter.RWCounter
 	forwardAttemptsTotal    promexporter.RWCounter
 	forwardedCountTotal     promexporter.RWCounter
 	forwardedLengthTotal    promexporter.RWCounter
@@ -26,6 +27,7 @@ func newClientMetrics(metricFactory *base.MetricFactory) clientMetrics {
 		queuedChunksPendingAck:  queuedChunks.WithLabelValues("pendingAck"),
 		networkErrorsTotal:      metricFactory.AddOrGetCounter("output_network_errors_total", "Numbers of network errors", nil, nil),
 		nonNetworkErrorsTotal:   metricFactory.AddOrGetCounter("output_nonnetwork_errors_total", "Numbers of non-network errors (auth, unexpected response, etc) from upstream", nil, nil),
+		openedSessionsTotal:     metricFactory.AddOrGetCounter("output_opened_sessions_total", "Numbers of opened sessions", nil, nil),
 		forwardAttemptsTotal:    metricFactory.AddOrGetCounter("output_forward_attempts_total", "Numbers of chunk forwarding attempts", nil, nil),
 		forwardedCountTotal:     metricFactory.AddOrGetCounter("output_forwarded_chunks_total", "Numbers of forwarded chunks", nil, nil),
 		forwardedLengthTotal:    metricFactory.AddOrGetCounter("output_forwarded_chunk_bytes_total", "Total length in bytes of forwarded chunks", nil, nil),
@@ -40,6 +42,10 @@ func (metrics *clientMetrics) OnError(err error) {
 	} else {
 		metrics.nonNetworkErrorsTotal.Inc()
 	}
+}
+
+func (metrics *clientMetrics) OnOpening() {
+	metrics.openedSessionsTotal.Inc()
 }
 
 func (metrics *clientMetrics) OnForwarding(chunk base.LogChunk) {

--- a/output/baseoutput/clientsession.go
+++ b/output/baseoutput/clientsession.go
@@ -10,7 +10,11 @@ import (
 	"github.com/relex/gotils/logger"
 	"github.com/relex/slog-agent/base"
 	"github.com/relex/slog-agent/defs"
+	"github.com/relex/slog-agent/util"
 )
+
+// softStopAcknowledgerChunk is a special chunk sent by main session to acknowledger, telling it to end
+var softStopAcknowledgerChunk = base.LogChunk{ID: "<soft-stop>", Data: nil, Saved: false}
 
 // clientSession represents a session bound to one forwarding connection
 type clientSession struct {
@@ -20,15 +24,25 @@ type clientSession struct {
 	onChunkAcked func(chunk base.LogChunk)
 	metrics      clientMetrics
 	conn         ClientConnection
-	leftovers    chan base.LogChunk        // unprocessed buffers from previous session(s)
-	lastChunk    *base.LogChunk            // last buffer in processing (to be added to leftovers if not completed)
-	ackerChan    chan base.LogChunk        // channel to pass buffers for acknowledger (wait for ACK and delete), close to end acknowledger
-	ackerQuit    *channels.SignalAwaitable // channel for acknowledger to signal its end
-	unacked      atomic.Value              // *[]base.LogChunk, un-ACK'ed buffers set when acknowledger quits (to be resent in next session)
+	leftovers    chan base.LogChunk        // unprocessed chunks from previous session(s)
+	lastChunk    *base.LogChunk            // last chunk in processing (to be added to leftovers if not completed)
+	ackerChan    chan base.LogChunk        // channel to pass chunks for acknowledger (wait for ACK and delete), close to end acknowledger
+	ackerEnded   *channels.SignalAwaitable // signal that acknowledger has ended
+	unacked      atomic.Value              // *[]base.LogChunk, un-ACK'ed chunks set when acknowledger quits (to be resent in next session)
 }
 
+type reconnectPolicy string
+type acknowledgerEnding string
+
+const (
+	reconnectWithDelay reconnectPolicy    = "reconnectWithDelay"
+	reconnect          reconnectPolicy    = "reconnect"
+	noReconnect        reconnectPolicy    = "noReconnect"
+	waitPendingChunks  acknowledgerEnding = "waitPendingChunks"
+	endImmediately     acknowledgerEnding = "endImmediately"
+)
+
 func newClientSession(client *ClientWorker, conn ClientConnection, leftovers chan base.LogChunk) *clientSession {
-	// set write buffer to 10MB
 	return &clientSession{
 		logger:       conn.Logger().WithField(defs.LabelPart, "session"),
 		inputChannel: client.inputChannel,
@@ -38,75 +52,91 @@ func newClientSession(client *ClientWorker, conn ClientConnection, leftovers cha
 		conn:         conn,
 		leftovers:    leftovers,
 		lastChunk:    nil,
-		ackerChan:    make(chan base.LogChunk, defs.ForwarderMaxBuffersForAck),
-		ackerQuit:    channels.NewSignalAwaitable(),
+		ackerChan:    make(chan base.LogChunk, defs.ForwarderMaxPendingChunksForAck),
+		ackerEnded:   channels.NewSignalAwaitable(),
 		unacked:      atomic.Value{},
 	}
 }
 
-func (session *clientSession) run() (chan base.LogChunk, bool) {
+func (session *clientSession) run(maxDuration time.Duration) (chan base.LogChunk, reconnectPolicy) {
 	go session.runAcknowledger()
+
 	// send leftovers from previous sessions
 	session.logger.Infof("begin recovery stage with leftovers=%d", len(session.leftovers))
+
 REPLAY_LEFTOVERS:
 	for {
 		var chunk base.LogChunk
 		var ok bool
-		// in
+
+		// get the next chunk to forward
 		select {
 		case <-session.inputClosed.Channel():
 			session.logger.Infof("stop requested (recovery stage)")
-			return session.collectLeftovers(), false
+			return session.collectLeftovers(endImmediately), noReconnect
+
 		case chunk, ok = <-session.leftovers:
 			if !ok {
-				session.logger.Errorf("BUG: aborted due to leftover channel closure")
-				return nil, false
+				session.logger.Errorf("BUG: aborted due to leftover channel closure. stack=%s", util.Stack())
+				return nil, noReconnect
 			}
 			session.metrics.OnLeftoverPopped(chunk)
 			session.logger.Debugf("resending: %v", &chunk)
 			session.lastChunk = &chunk
+
 		default:
 			// break as soon as there is no leftover to process
 			break REPLAY_LEFTOVERS
 		}
-		// out
+
+		// forward chunk
 		continueSession, netErr := session.sendChunk(chunk)
 		switch {
 		case netErr != nil:
-			return session.collectLeftovers(), true
+			return session.collectLeftovers(endImmediately), reconnectWithDelay
 		case !continueSession:
-			return session.collectLeftovers(), false
+			return session.collectLeftovers(endImmediately), noReconnect
 		default:
 			session.lastChunk = nil
 		}
 	}
-	// send buffers from the channel
+
+	maxSessionDurationSignal := time.After(maxDuration)
+
 	session.logger.Infof("begin normal stage with queued=%d", len(session.inputChannel))
 	for {
 		var chunk base.LogChunk
 		var ok bool
-		// in
+
+		// get the next chunk to forward
 		select {
 		case chunk, ok = <-session.inputChannel:
 			if !ok {
 				session.logger.Infof("stop requested (normal stage)")
-				return session.collectLeftovers(), false
+				return session.collectLeftovers(endImmediately), noReconnect
 			}
 			session.logger.Debugf("received new: %v", &chunk)
 			session.lastChunk = &chunk
-		case <-time.After(defs.ForwarderPingInterval):
+
+		case <-maxSessionDurationSignal:
+			session.logger.Info("max session duration reached, stopping to reconnect")
+			return session.collectLeftovers(waitPendingChunks), reconnect
+
+		case <-time.After(defs.ForwarderPingInterval): // send ping (keep-alive) if there is no new log
 			if err := session.sendPing(); err != nil {
-				return session.collectLeftovers(), true
+				return session.collectLeftovers(endImmediately), reconnectWithDelay
 			}
 			continue
 		}
-		// out
+
+		// forward chunk
 		continueSession, netErr := session.sendChunk(chunk)
 		switch {
 		case netErr != nil:
-			return session.collectLeftovers(), true
+			return session.collectLeftovers(endImmediately), reconnectWithDelay
 		case !continueSession:
-			return session.collectLeftovers(), false
+			return session.collectLeftovers(endImmediately), noReconnect
+
 		default:
 			session.lastChunk = nil
 		}
@@ -122,15 +152,17 @@ func (session *clientSession) sendChunk(chunk base.LogChunk) (bool, error) {
 		session.metrics.OnError(err)
 		return true, err
 	}
+
+	// pass forwarded chunk to acknowledger
 	select {
 	case session.ackerChan <- chunk:
 		break
 	case <-session.inputClosed.Channel():
-		session.logger.Infof("aborted before queueing ack buf due to stop request: %s", chunk.String())
+		session.logger.Infof("aborted before queueing chunk for ack due to stop request: %s", chunk.String())
 		return false, nil
-	case <-session.ackerQuit.Channel():
+	case <-session.ackerEnded.Channel():
 		// acknowledger terminated due to invalid server response, return true and error for reconnection
-		err := fmt.Errorf("aborted before queueing ack buf due to termination of acknowledger: %s", chunk.String())
+		err := fmt.Errorf("aborted before queueing chunk for ack due to termination of acknowledger: %s", chunk.String())
 		session.logger.Info(err.Error())
 		return true, err
 	}
@@ -149,25 +181,51 @@ func (session *clientSession) sendPing() error {
 	return nil
 }
 
-func (session *clientSession) collectLeftovers() chan base.LogChunk {
+func (session *clientSession) collectLeftovers(ending acknowledgerEnding) chan base.LogChunk {
 	// gather previous leftovers
 	close(session.leftovers)
-	fromPrevious := channelToBuffer(session.leftovers)
+	fromPrevious := collectChunksFromChannel(session.leftovers, session.logger)
 
-	// stop acknowledger and gather unread chunks from its input channel
-	session.logger.Info("stopping acknowledger")
-	close(session.ackerChan)
-	if !session.ackerQuit.Wait(defs.ForwarderAckerStopTimeout) {
-		session.logger.Error("BUG: timeout waiting for acknowledger to stop")
+	closeAckerChanAfterEnded := false
+	switch ending {
+	case waitPendingChunks:
+		session.logger.Info("pushing soft-stop command to acknowledger")
+		select {
+		case session.ackerChan <- softStopAcknowledgerChunk: // attempt to queue the command (which would be the last)
+			session.logger.Info("pushed soft-stop command to acknowledger")
+			closeAckerChanAfterEnded = true // close after ackerEnded for collection of remaining chunks
+		case <-time.After(defs.ForwarderAckerStopTimeout):
+			session.logger.Error("timeout pushing soft-stop command to acknowledger, abort now")
+			close(session.ackerChan)
+		case <-session.inputClosed.Channel():
+			session.logger.Infof("received stop request while pushing soft-stop command, abort now")
+			close(session.ackerChan)
+		case <-session.ackerEnded.Channel():
+			// acknowledger already terminated due to invalid server response
+			session.logger.Info("acknowledger terminated while pushing soft-stop command, abort now")
+			close(session.ackerChan)
+		}
+	case endImmediately:
+		session.logger.Info("stopping acknowledger")
+		close(session.ackerChan)
+	default:
+		session.logger.Panic("invalid ending type: ", ending)
 	}
-	fromAckerChannel := channelToBuffer(session.ackerChan)
 
-	// gather pendings chunks left in runAcknowledger's pendingAckBufMap
+	if !session.ackerEnded.Wait(defs.ForwarderAckerStopTimeout) {
+		session.logger.Errorf("BUG: timeout waiting for acknowledger to stop. stack=%s", util.Stack())
+	}
+	if closeAckerChanAfterEnded {
+		close(session.ackerChan)
+	}
+	fromAckerChannel := collectChunksFromChannel(session.ackerChan, session.logger)
+
+	// gather pendings chunks left in runAcknowledger's pendingChunksByID
 	var fromAckerPending []base.LogChunk
 	if pendingListPtr := session.unacked.Load().(*[]base.LogChunk); pendingListPtr != nil {
 		fromAckerPending = *pendingListPtr
 	} else {
-		session.logger.Error("BUG: failed to get un-ACK'ed chunks from acknowledger")
+		session.logger.Errorf("BUG: failed to get un-ACK'ed chunks from acknowledger. stack=%s", util.Stack())
 	}
 
 	// merge
@@ -185,7 +243,7 @@ func (session *clientSession) collectLeftovers() chan base.LogChunk {
 	session.metrics.OnSessionEnded(len(fromPrevious), len(fromAckerChannel)+len(fromAckerPending), len(newLeftovers))
 
 	// remove duplicates
-	newLeftoversChan := bufferToChannel(newLeftovers)
+	newLeftoversChan := newLeftoverChannel(newLeftovers)
 	session.logger.Infof("collected leftovers: prev(%d) + chan(%d) + unack(%d) + inproc(%d) = unique(%d)",
 		len(fromPrevious), len(fromAckerChannel), len(fromAckerPending), inproc, len(newLeftoversChan))
 
@@ -201,7 +259,7 @@ func (session *clientSession) runAcknowledger() {
 			values = append(values, v)
 		}
 		session.unacked.Store(&values)
-		session.ackerQuit.Signal()
+		session.ackerEnded.Signal()
 	}()
 	for {
 		var nextChunk base.LogChunk
@@ -213,12 +271,24 @@ func (session *clientSession) runAcknowledger() {
 				clogger.Infof("stop requested")
 				return
 			}
+			// check for soft-stop command which tells acknowledger to end gracefully
+			// we can safely return here, because unlike the hard channel closing which is immediately in effect,
+			// by the time we get the soft-stop command, all pending chunks have been received and processed already
+			if chunk.ID == softStopAcknowledgerChunk.ID {
+				if len(pendingChunksByID) > 0 {
+					clogger.Errorf("soft-stop requested while there are still pending chunks: %d", len(pendingChunksByID))
+				} else {
+					clogger.Info("soft-stop requested")
+				}
+				return
+			}
 			pendingChunksByID[chunk.ID] = chunk
 			nextChunk = chunk
 			clogger.Debugf("received pending chunk %s", chunk.ID)
 		}
 
-		// wait for acknowledgement from upstream
+		// wait for next acknowledgement from upstream with timeout,
+		// normally it should match the chunk we just received from ackerChan
 		ackedChunkID, ackErr := session.conn.ReadChunkAck(time.Now().Add(defs.ForwarderBatchAckTimeout))
 		if ackErr != nil {
 			clogger.Warnf("failed to read ACK: %s", ackErr.Error())
@@ -240,31 +310,45 @@ func (session *clientSession) runAcknowledger() {
 			}
 		}
 
-		// clean up
+		// clean up the chunk we just processed
 		delete(pendingChunksByID, nextChunk.ID)
 		session.onChunkAcked(nextChunk)
 		session.metrics.OnAcknowledged(nextChunk)
 	}
 }
 
-func channelToBuffer(bufChan chan base.LogChunk) []base.LogChunk {
-	collected := make([]base.LogChunk, 0, len(bufChan)+20)
-	for c := range bufChan {
+// collectChunksFromChannel collect remaining chunks from a CLOSED channel
+func collectChunksFromChannel(chunkChan chan base.LogChunk, logger logger.Logger) []base.LogChunk {
+	// check if channel is still open. for loop on open channel would hang FOREVER
+	select {
+	case c, ok := <-chunkChan:
+		if ok {
+			logger.Errorf("BUG: collecting from open channel, chunk lost=%s. stack=%s", c, util.Stack())
+			close(chunkChan)
+		}
+	default:
+		logger.Errorf("BUG: collecting from open channel. stack=%s", util.Stack())
+		close(chunkChan)
+	}
+
+	collected := make([]base.LogChunk, 0, len(chunkChan)+20)
+	for c := range chunkChan {
 		collected = append(collected, c)
 	}
 	return collected
 }
 
-func bufferToChannel(buffers []base.LogChunk) chan base.LogChunk {
-	sort.Slice(buffers, func(i, j int) bool { return buffers[i].ID < buffers[j].ID })
-	channel := make(chan base.LogChunk, len(buffers))
+// newLeftoverChannel creates a new channel filled with leftover chunks, sorted and deduplicated
+func newLeftoverChannel(chunks []base.LogChunk) chan base.LogChunk {
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].ID < chunks[j].ID })
+	channel := make(chan base.LogChunk, len(chunks))
 	lastChunkID := "" // to skip duplications
-	for _, b := range buffers {
-		if b.ID == lastChunkID {
+	for _, c := range chunks {
+		if c.ID == lastChunkID {
 			continue
 		}
-		channel <- b
-		lastChunkID = b.ID
+		channel <- c
+		lastChunkID = c.ID
 	}
 	return channel
 }

--- a/output/fluentdforward/clientworker.go
+++ b/output/fluentdforward/clientworker.go
@@ -35,6 +35,7 @@ func NewClientWorker(parentLogger logger.Logger, args base.ChunkConsumerArgs, co
 		func() (baseoutput.ClientConnection, error) {
 			return openForwardConnection(clientLogger, config)
 		},
+		config.MaxDuration,
 	)
 }
 

--- a/output/fluentdforward/config.go
+++ b/output/fluentdforward/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/relex/fluentlib/protocol/forwardprotocol"
 	"github.com/relex/gotils/logger"
@@ -30,9 +31,10 @@ type SerializationConfig struct {
 
 // UpstreamConfig defines the upstream section in config file
 type UpstreamConfig struct {
-	Address string `yaml:"address"`
-	TLS     bool   `yaml:"tls"`
-	Secret  string `yaml:"secret"`
+	Address     string        `yaml:"address"`
+	TLS         bool          `yaml:"tls"`
+	Secret      string        `yaml:"secret"`
+	MaxDuration time.Duration `yaml:"maxDuration"`
 }
 
 // DumpRecordsAsJSON decodes and dumps log records in chunk as JSON format
@@ -95,6 +97,10 @@ func (cfg *Config) VerifyConfig(schema base.LogSchema) error {
 
 	if cfg.Upstream.TLS && len(cfg.Upstream.Secret) == 0 {
 		return fmt.Errorf(".upstream.secret is unspecified when tls=true")
+	}
+
+	if cfg.Upstream.MaxDuration == 0 {
+		return fmt.Errorf(".upstream.maxDuration is unspecified")
 	}
 	return nil
 }

--- a/testdata/config_sample.yml
+++ b/testdata/config_sample.yml
@@ -138,7 +138,7 @@ transformations:
             match:
               source: auth.log
               level: !!str-not fatal
-            label: app-auth                       # label: a metric label value to track dropped logs, e.g.
+            metricLabel: app-auth                 # metricLabel: a metric label value to track dropped logs, e.g.
                                                   #   slogagent_process_labelled_record_bytes_total{key_app="appServ",key_vhost="foo.com",label="app-auth"} 175
 
           - type: switch                          
@@ -159,7 +159,7 @@ transformations:
                 then:
                   - type: redactEmail             # redactEmail: search and redact emails in-place
                     key: log                      # key: field to check and redact
-                    label: redacted               # label: a metric label value to track changed logs (not numbers of emails redacted)
+                    metricLabel: redacted         # metricLabel: a metric label value to track changed logs (not numbers of emails redacted)
 
       - match:
           app: abandoned
@@ -272,3 +272,4 @@ output:
     address: localhost:24224
     tls: true
     secret: guess
+    maxDuration: 30m

--- a/testdata/config_sample_dump.yml
+++ b/testdata/config_sample_dump.yml
@@ -80,7 +80,7 @@ transformations:
             match:
               level: '!= fatal'
               source: == auth.log
-            label: app-auth
+            metricLabel: app-auth
           - type: switch
             cases:
               - match:
@@ -99,7 +99,7 @@ transformations:
                 then:
                   - type: redactEmail
                     key: log
-                    label: redacted
+                    metricLabel: redacted
       - match:
           app: == abandoned
         then:
@@ -161,3 +161,4 @@ output:
     address: localhost:24224
     tls: true
     secret: guess
+    maxDuration: 30m0s

--- a/transform/tdrop/tdrop.go
+++ b/transform/tdrop/tdrop.go
@@ -14,7 +14,7 @@ import (
 type Config struct {
 	bconfig.Header `yaml:",inline"`
 	Match          bmatch.LogMatcherConfig `yaml:"match"`
-	Label          string                  `yaml:"label"`
+	MetricLabel    string                  `yaml:"metricLabel"`
 }
 
 type dropTransform struct {
@@ -26,7 +26,7 @@ type dropTransform struct {
 func (cfg *Config) NewTransform(schema base.LogSchema, parentLogger logger.Logger, customCounterRegistry base.LogCustomCounterRegistry) base.LogTransform {
 	tf := &dropTransform{
 		matcher: cfg.Match.NewMatcher(schema),
-		counter: customCounterRegistry.RegisterCustomCounter(cfg.Label),
+		counter: customCounterRegistry.RegisterCustomCounter(cfg.MetricLabel),
 	}
 	return tf
 }
@@ -39,8 +39,8 @@ func (cfg *Config) VerifyConfig(schema base.LogSchema) error {
 	if err := cfg.Match.VerifyConfig(schema); err != nil {
 		return fmt.Errorf(".match: %w", err)
 	}
-	if len(cfg.Label) == 0 {
-		return fmt.Errorf(".label is unspecified")
+	if len(cfg.MetricLabel) == 0 {
+		return fmt.Errorf(".metricLabel is unspecified")
 	}
 	return nil
 }

--- a/transform/tdrop/tdrop_test.go
+++ b/transform/tdrop/tdrop_test.go
@@ -18,7 +18,7 @@ func TestDropTransform(t *testing.T) {
 type: drop
 match:
   name: Foo
-label: test
+metricLabel: test
 `, c))
 		tf := c.NewTransform(schema, logger.Root(), bsupport.NewStubLogCustomCounterRegistry())
 		{

--- a/transform/tredactemail/tredactemail.go
+++ b/transform/tredactemail/tredactemail.go
@@ -13,7 +13,7 @@ import (
 type Config struct {
 	bconfig.Header `yaml:",inline"`
 	Key            string `yaml:"key"`
-	Label          string `yaml:"label"`
+	MetricLabel    string `yaml:"metricLabel"`
 }
 
 type redactEmailTransform struct {
@@ -25,7 +25,7 @@ type redactEmailTransform struct {
 func (cfg *Config) NewTransform(schema base.LogSchema, parentLogger logger.Logger, customCounterRegistry base.LogCustomCounterRegistry) base.LogTransform {
 	tf := &redactEmailTransform{
 		keyLocator: schema.MustCreateFieldLocator(cfg.Key),
-		counter:    customCounterRegistry.RegisterCustomCounter(cfg.Label),
+		counter:    customCounterRegistry.RegisterCustomCounter(cfg.MetricLabel),
 	}
 	return tf
 }
@@ -38,8 +38,8 @@ func (cfg *Config) VerifyConfig(schema base.LogSchema) error {
 	if _, err := schema.CreateFieldLocator(cfg.Key); err != nil {
 		return fmt.Errorf(".key '%s' is invalid: %w", cfg.Key, err)
 	}
-	if len(cfg.Label) == 0 {
-		return fmt.Errorf(".label is unspecified")
+	if len(cfg.MetricLabel) == 0 {
+		return fmt.Errorf(".metricLabel is unspecified")
 	}
 	return nil
 }

--- a/transform/tredactemail/tredactemail_test.go
+++ b/transform/tredactemail/tredactemail_test.go
@@ -17,7 +17,7 @@ func TestRedactEmailTransform(t *testing.T) {
 		assert.Nil(t, util.UnmarshalYamlString(`
 type: redactEmail
 key: log
-label: email
+metricLabel: email
 `, c))
 		tf := c.NewTransform(schema, logger.Root(), bsupport.NewStubLogCustomCounterRegistry())
 		{


### PR DESCRIPTION
Metrics:

- configurable metric labels are renamed from "label"

Common output: (affecting Fluentd output mainly)

- Allow session opening to be interrupted without waiting for timeout
- Allow session to be interrupted while sending log batches without waiting for timeout
- Add configurable max duration for sessions to help load balancing. When a session is closed due to max duration, it waits for ACK gracefully and there would be no delay before next session.

The changes made output even more complicated and this will be addressed in #17


Co-authored-by: Federico Leva <federico.leva@relexsolutions.com>
Co-authored-by: Johannes Staffans <johannes.staffans@relexsolutions.com>
Co-authored-by: Pedro Trigueros <pedro.trigueros@relexsolutions.com>