### PR TITLE
output: Fix connection leak in fast-shutdown, handle repeated Close()

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,53 @@
+# Manual integration testing
+
+A basic test setup for slog-agent is like:
+
+1. Start upstream: run `fluentlibtool server` provided by [fluentlib](https://github.com/relex/fluentlib) as a fake Fluentd
+2. Start agent: run `BUILD/slog-agent run --config=testdata/config_sample.yml`
+3. Feed input: `cat testdata/development/*.log > /dev/tcp/127.0.0.1/5140`
+
+## Current coverage
+
+- Buffer (HybridBuffer): recovery mechanism
+- Input (Syslog): parsing, error handling
+- Orchestrate (ByKeySetOrchestrator): distribution by key-set (= label sets)
+- Rewrite and Transform: fully covered by unit tests
+- Run: config initialization and reloading
+
+## Areas lacking tests
+
+### Orchestrate: parallel sub-pipelines
+
+It's a replacement / augment of ByKeySetOrchestrator to split each key-set pipeline into fixed numbers of parallel
+subpipelines, which receive log chunks from the ParallelDistributor which splits traffic.
+
+Due to the requirements from Loki storage, log chunks have to be collected in the original order though they may be
+processed in parallel. Mutexes in *OrderedLogBuffer* are used to synchronize and ensure the order.
+
+The code involves:
+
+  - base/bsupport/orderedlogprocessingworker.go: OrderedLogProcessingWorker
+  - base/bsupport/pipelineparallel.go: ParallelPipeline*
+  - orchestrate/obase/distributor.go: ParallelDistributor
+
+### Output: error recovery
+
+The normal code-path for output is already covered, but not any of error related paths that are critical to production
+environments. Those code are concentrated in:
+
+  - `output/baseoutput/clientsession.go`
+  - `output/baseoutput/clientworker.go`
+
+Some of the expected errors and special code-paths are:
+
+  - Fluentd keeps receiving chunks but not responding
+  - Log chunks sent unsuccessfully
+  - Log chunks sent but not acknowledged
+  - Interruption in recovery stage before all leftover chunks from the previous session can be sent
+  - Sessions reach their max duration and abort for reconnection
+  - The need to abort connection when a shutdown signal is received, in order to interrupt any ongoing read/write
+
+Except the session max-duration which can be tested by using very short `upstream/maxDuration` in config, the rest may
+be helped by emulation of random network or Fluentd errors in [fluentlib](https://github.com/relex/fluentlib) and
+`--test_mode` of the agent, but there are no automated tests as it'd require not only to verify the final output but
+also certain code paths being touched and the contents of certain variables at certain stages.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/relex/slog-agent
 
-go 1.15
+go 1.16
 
 require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2

--- a/output/baseoutput/clientprovider.go
+++ b/output/baseoutput/clientprovider.go
@@ -7,36 +7,41 @@ import (
 	"github.com/relex/slog-agent/base"
 )
 
-// EstablishConnectionFunc opens a ClientConnection to upstream
-type EstablishConnectionFunc func() (ClientConnection, error)
+// EstablishConnectionFunc opens a ClosableClientConnection to upstream
+type EstablishConnectionFunc func() (ClosableClientConnection, error)
 
 // ClientConnection represents a connection / session / channel to upstream.
 //
-// It must support full-duplex or desynchronized input and output to allow pipelining, i.e. send next chunk without
-// waiting for the current chunk to finish
+// It must support full-duplex or desynchronized input and output to allow pipelining, i.e. send next chunks without
+// waiting for the current chunk to be acknowledged.
 type ClientConnection interface {
 
 	// Logger returns the logger bound to this connection
 	Logger() logger.Logger
 
-	// SendChunk sends out the given chunk to remote
+	// SendChunk sends out the given chunk to remote destination
 	SendChunk(chunk base.LogChunk, deadline time.Time) error
 
-	// SendPing sends a ping singal every N seconds, depending on the caller
+	// SendPing sends a ping signal.
 	//
 	// If ping is not supported by the underlying protocol, the function should do nothing
 	SendPing(deadline time.Time) error
 
-	// ReadChunkAck reads an ID of an acknowledged chunk
+	// ReadChunkAck reads the ID of a previously-sent chunk once it's acknowledged.
 	//
 	// Acknowledgement of chunks by upstream is not required to be in the same order they were sent.
 	//
-	// If the order is maintained, it may return empty string to simply indicate the next chunk.
+	// If the order is strictly maintained, it may return empty string to indicate the last unacknowledged chunk.
 	ReadChunkAck(deadline time.Time) (string, error)
+}
+
+// ClosableClientConnection is ClientConnection with Close method
+type ClosableClientConnection interface {
+	ClientConnection
 
 	// Close closes the connection
 	//
-	// Close may be called more than once and/or simultaneously. The implementation must handle such situations
-	// silently and avoid e.g. closing a previously-closed FD, which might have been reused for something else.
+	// Close may be called simultaneously while sending or reading is still in progress, and it must be able to cancel
+	// ongoing operations immediately.
 	Close()
 }

--- a/output/baseoutput/clientprovider.go
+++ b/output/baseoutput/clientprovider.go
@@ -29,9 +29,10 @@ type ClientConnection interface {
 
 	// ReadChunkAck reads the ID of a previously-sent chunk once it's acknowledged.
 	//
-	// Acknowledgement of chunks by upstream is not required to be in the same order they were sent.
+	// If the order of acknowledgement by upstream is the same as the sending order, the function may return an empty
+	// string to indicate it's the first of previously-unacknowledged chunks.
 	//
-	// If the order is strictly maintained, it may return empty string to indicate the last unacknowledged chunk.
+	// Otherwise, a non-empty ID must be returned to indicate which chunk was acknowledged exactly.
 	ReadChunkAck(deadline time.Time) (string, error)
 }
 

--- a/output/baseoutput/clientprovider.go
+++ b/output/baseoutput/clientprovider.go
@@ -36,6 +36,7 @@ type ClientConnection interface {
 
 	// Close closes the connection
 	//
-	// Close may be called multiple times and it's not considered an error.
+	// Close may be called more than once and/or simultaneously. The implementation must handle such situations
+	// silently and avoid e.g. closing a previously-closed FD, which might have been reused for something else.
 	Close()
 }

--- a/output/baseoutput/clientworker.go
+++ b/output/baseoutput/clientworker.go
@@ -60,9 +60,9 @@ func NewClientWorker(parentLogger logger.Logger, args base.ChunkConsumerArgs, me
 	client.inputClosed.Next(func() {
 		sess := (*clientSession)(atomic.LoadPointer(&client.activeSession))
 		if sess != nil {
-			if sess.Abort() {
+			sess.Abort(func() {
 				client.logger.Info("abort ongoing connection due to stop request")
-			}
+			})
 		}
 	})
 
@@ -154,9 +154,9 @@ func (client *ClientWorker) runSession(leftovers chan base.LogChunk) (chan base.
 	atomic.StorePointer(&client.activeSession, unsafe.Pointer(sess))
 
 	defer func() {
-		if sess.Abort() {
-			client.logger.Info("close connection")
-		}
+		sess.Abort(func() {
+			client.logger.Info("close connection at the end of session")
+		})
 		atomic.StorePointer(&client.activeSession, nil)
 	}()
 

--- a/util/runonce.go
+++ b/util/runonce.go
@@ -6,19 +6,21 @@ import (
 
 // RunOnce is a function wrapper that calls the underlying function at most once
 //
-// Returns true when the wrapper function is actually called
+// beforeRunning is invoked right before the underlying function is invoked and only if it's going to be invoked.
+// It may be nil.
 //
 // This can be used to protect e.g. resource closing or cleanup, which should be called exactly once
-type RunOnce func() bool
+type RunOnce func(beforeRunning func())
 
 // NewRunOnce creates a function that would call the given "f" at most once
-func NewRunOnce(f func()) func() bool {
+func NewRunOnce(f func()) RunOnce {
 	var invoked int32 = 0
-	return func() bool {
+	return func(beforeRunning func()) {
 		if atomic.CompareAndSwapInt32(&invoked, 0, 1) {
+			if beforeRunning != nil {
+				beforeRunning()
+			}
 			f()
-			return true
 		}
-		return false
 	}
 }

--- a/util/runonce.go
+++ b/util/runonce.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"sync/atomic"
+)
+
+// RunOnce is a function wrapper that calls the underlying function at most once
+//
+// Returns true when the wrapper function is actually called
+//
+// This can be used to protect e.g. resource closing or cleanup, which should be called exactly once
+type RunOnce func() bool
+
+// NewRunOnce creates a function that would call the given "f" at most once
+func NewRunOnce(f func()) func() bool {
+	var invoked int32 = 0
+	return func() bool {
+		if atomic.CompareAndSwapInt32(&invoked, 0, 1) {
+			f()
+			return true
+		}
+		return false
+	}
+}


### PR DESCRIPTION
baseoutput/clientsession.go: Refactoring
baseoutput/clientworker.go: Fix connection/goroutine leak caused by fast shutdown
fluentdforward/clientworker.go: Handle repeated `Close()`